### PR TITLE
#15 ログインの実装

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from "@/lib/auth";
 import AccountCircle from "@mui/icons-material/AccountCircle";
 import AppBar from "@mui/material/AppBar";
 import IconButton from "@mui/material/IconButton";
@@ -6,16 +7,12 @@ import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import * as React from "react";
+import { Link } from "react-router-dom";
+import { useHandleMenu } from "./hooks";
 
 export const Header = React.memo(() => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const { user } = useAuth();
+  const { anchorEl, closeMenu, openMenu } = useHandleMenu();
 
   return (
     <AppBar position="fixed">
@@ -27,35 +24,37 @@ export const Header = React.memo(() => {
           sx={{ flexGrow: 1 }}
           align="center"
         >
-          ポイントアプリ
+          <Link to="/">ポイントアプリ</Link>
         </Typography>
-        <IconButton
-          size="large"
-          aria-label="account of current user"
-          aria-controls="menu-appbar"
-          aria-haspopup="true"
-          onClick={handleMenu}
-          color="inherit"
-        >
-          <AccountCircle />
-        </IconButton>
-        <Menu
-          anchorEl={anchorEl}
-          anchorOrigin={{
-            vertical: "top",
-            horizontal: "right",
-          }}
-          keepMounted
-          transformOrigin={{
-            vertical: "top",
-            horizontal: "right",
-          }}
-          open={Boolean(anchorEl)}
-          onClose={handleClose}
-        >
-          <MenuItem onClick={handleClose}>アカウント情報</MenuItem>
-          <MenuItem onClick={handleClose}>サインアウト</MenuItem>
-        </Menu>
+        {user && (
+          <>
+            <IconButton
+              size="large"
+              aria-label="ユーザメニュー"
+              onClick={openMenu}
+              color="inherit"
+            >
+              <AccountCircle />
+            </IconButton>
+            <Menu
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: "top",
+                horizontal: "right",
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: "top",
+                horizontal: "right",
+              }}
+              open={Boolean(anchorEl)}
+              onClose={closeMenu}
+            >
+              <MenuItem onClick={closeMenu}>アカウント情報</MenuItem>
+              <MenuItem onClick={closeMenu}>サインアウト</MenuItem>
+            </Menu>
+          </>
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/src/components/Header/hooks.ts
+++ b/src/components/Header/hooks.ts
@@ -1,0 +1,24 @@
+import React from "react";
+
+/**
+ * メニューの開閉を扱うフック
+ * @returns anchorEl メニューを表示したいエレメント
+ * @returns closeMenu メニューを閉じる
+ * @returns openMenu 目ミューを開く
+ */
+export const useHandleMenu = () => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const openMenu = React.useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [setAnchorEl]
+  );
+
+  const closeMenu = React.useCallback(() => {
+    setAnchorEl(null);
+  }, [setAnchorEl]);
+
+  return { closeMenu, openMenu, anchorEl };
+};

--- a/src/const/const.ts
+++ b/src/const/const.ts
@@ -1,4 +1,21 @@
+// 共通
 export const ERR_REQUIRE_MESSAGE = "必須項目です。";
+
+// メールアドレス
 export const ERR_MAIL_FORMAT_MESSAGE = "メール形式にしてください。";
 export const MAIL_FORMAT_REGEXP =
   /^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/;
+export const MAX_MAIL_LENGTH = {
+  VALUE: 256,
+  MESSAGE: "256文字以下で入力してください。",
+};
+
+// パスワード
+export const MAX_PASSWORD_LENGTH = {
+  VALUE: 50,
+  MESSAGE: "50文字以下で入力してください。",
+};
+export const MIN_PASSWORD_LENGTH = {
+  VALUE: 8,
+  MESSAGE: "8文字以上で入力してください。",
+};

--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -1,4 +1,14 @@
+import { axios, SuccessResponse } from "@/lib/axios";
+
 export type LoginCredentialsDTO = {
   email: string;
   password: string;
+};
+
+export type LoginCredentialsResponse = SuccessResponse<{
+  accessToken: string;
+}>;
+
+export const loginWithEmailAndPassword = (data: LoginCredentialsDTO) => {
+  return axios.post<LoginCredentialsResponse>("/tokens", data);
 };

--- a/src/features/auth/component/arrowLink.tsx
+++ b/src/features/auth/component/arrowLink.tsx
@@ -1,0 +1,18 @@
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import React from "react";
+import { Link } from "react-router-dom";
+
+type Props = {
+  children: React.ReactNode;
+} & React.ComponentProps<typeof Link>;
+
+/**
+ * リンクコンポーネント
+ * react-router-domのLinkコンポーネントをラップ
+ */
+export const ArrowLink = React.memo(({ children, ...props }: Props) => (
+  <Link style={{ color: "#1976d2", textDecoration: "underline" }} {...props}>
+    <span>{children}</span>
+    <KeyboardArrowRightIcon style={{ height: "40px", marginBottom: "-15px" }} />
+  </Link>
+));

--- a/src/features/auth/component/login.tsx
+++ b/src/features/auth/component/login.tsx
@@ -1,0 +1,112 @@
+import {
+  ERR_MAIL_FORMAT_MESSAGE,
+  ERR_REQUIRE_MESSAGE,
+  MAIL_FORMAT_REGEXP,
+  MAX_MAIL_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
+} from "@/const/const";
+import { useAuth } from "@/lib/auth";
+import { LoadingButton } from "@mui/lab";
+import { Box, TextField } from "@mui/material";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { ArrowLink } from "./arrowLink";
+
+/**
+ * ログイン機能
+ */
+export const Login: React.FC = React.memo(() => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+  const navigate = useNavigate();
+  const { login, isLoggingIn, error } = useAuth();
+
+  return (
+    <Box className="App" mx="auto" maxWidth="400px" mt="100px">
+      <Box textAlign="center" component="h2" mb="60px" color="#333">
+        ログイン
+      </Box>
+      <form
+        onSubmit={handleSubmit(async (data) => {
+          await login(data);
+          navigate("/users");
+        })}
+      >
+        <Box marginBottom="24px">
+          <Box mb="4px">メールアドレス</Box>
+          <TextField
+            fullWidth
+            placeholder="yamada.taro@example.com"
+            variant="outlined"
+            {...register("email", {
+              required: { value: true, message: ERR_REQUIRE_MESSAGE },
+              pattern: {
+                value: MAIL_FORMAT_REGEXP,
+                message: ERR_MAIL_FORMAT_MESSAGE,
+              },
+              maxLength: {
+                value: MAX_MAIL_LENGTH.VALUE,
+                message: MAX_MAIL_LENGTH.MESSAGE,
+              },
+            })}
+          />
+          <Box sx={{ color: "error.main" }}>{errors.email?.message}</Box>
+        </Box>
+        <Box marginBottom="24px">
+          <Box mb="4px">パスワード</Box>
+          <TextField
+            fullWidth
+            type="password"
+            variant="outlined"
+            placeholder="********"
+            {...register("password", {
+              required: { value: true, message: ERR_REQUIRE_MESSAGE },
+              minLength: {
+                value: MIN_PASSWORD_LENGTH.VALUE,
+                message: MIN_PASSWORD_LENGTH.MESSAGE,
+              },
+              maxLength: {
+                value: MAX_PASSWORD_LENGTH.VALUE,
+                message: MAX_PASSWORD_LENGTH.MESSAGE,
+              },
+            })}
+          />
+          <Box sx={{ color: "error.main" }}>{errors.password?.message}</Box>
+          <Box color="error.main">{error?.response?.data.message}</Box>
+        </Box>
+        <LoadingButton
+          size="large"
+          fullWidth
+          sx={{ marginTop: "50px" }}
+          variant="contained"
+          type="submit"
+          color="primary"
+          loading={isLoggingIn}
+        >
+          ログイン
+        </LoadingButton>
+        <Box my="80px" />
+        <Box textAlign="center" mb="20px">
+          <ArrowLink to="/signup" aria-label="アカウント作成はこちら">
+            アカウント新規作成はこちら
+          </ArrowLink>
+        </Box>
+        <Box textAlign="center">
+          <ArrowLink to="/password-reset" aria-label="アカウント作成はこちら">
+            パスワードを忘れた方はこちら
+          </ArrowLink>
+        </Box>
+      </form>
+    </Box>
+  );
+});

--- a/src/features/auth/component/signup.tsx
+++ b/src/features/auth/component/signup.tsx
@@ -2,6 +2,9 @@ import {
   ERR_MAIL_FORMAT_MESSAGE,
   ERR_REQUIRE_MESSAGE,
   MAIL_FORMAT_REGEXP,
+  MAX_MAIL_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
 } from "@/const/const";
 import { LoadingButton } from "@mui/lab";
 import { Box, TextField } from "@mui/material";
@@ -64,8 +67,8 @@ export const Signup: React.FC = React.memo(() => {
   );
 
   return (
-    <Box className="App" mx="auto" maxWidth="400px">
-      <Box textAlign="center" component="h2">
+    <Box className="App" mx="auto" maxWidth="400px" mt="100px">
+      <Box textAlign="center" component="h2" mb="60px" color="#333">
         アカウント新規登録
       </Box>
       <form onSubmit={handleSubmit((data) => mutate(data))}>
@@ -81,6 +84,10 @@ export const Signup: React.FC = React.memo(() => {
               pattern: {
                 value: MAIL_FORMAT_REGEXP,
                 message: ERR_MAIL_FORMAT_MESSAGE,
+              },
+              maxLength: {
+                value: MAX_MAIL_LENGTH.VALUE,
+                message: MAX_MAIL_LENGTH.MESSAGE,
               },
             })}
           />
@@ -150,6 +157,14 @@ export const Signup: React.FC = React.memo(() => {
             variant="outlined"
             {...register("password", {
               required: { value: true, message: ERR_REQUIRE_MESSAGE },
+              minLength: {
+                value: MIN_PASSWORD_LENGTH.VALUE,
+                message: MIN_PASSWORD_LENGTH.MESSAGE,
+              },
+              maxLength: {
+                value: MAX_PASSWORD_LENGTH.VALUE,
+                message: MAX_PASSWORD_LENGTH.MESSAGE,
+              },
             })}
           />
           <Box sx={{ color: "error.main" }}>{errors.password?.message}</Box>

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,6 +1,9 @@
 import { RegisterCredentialsDTO, registerUser } from "@/features/auth";
 import { getUser } from "@/features/auth/api/getUser";
-import { LoginCredentialsDTO } from "@/features/auth/api/login";
+import {
+  LoginCredentialsDTO,
+  loginWithEmailAndPassword,
+} from "@/features/auth/api/login";
 import { ErrResponse } from "@/lib/axios";
 import { initReactQueryAuth } from "@/lib/react-query-auth";
 import storage from "@/utils/storage";
@@ -18,26 +21,25 @@ async function loadUser() {
 }
 
 async function loginFn(data: LoginCredentialsDTO) {
-  // const response = await loginWithEmailAndPassword(data);
-  // const user = await handleUserResponse(response);
-  // TODO: 一旦固定値
-  return {
-    email: "",
-    firstName: "",
-    firstNameKana: "",
-    familyName: "",
-    familyNameKana: "",
-    acquisitionPoint: 0,
-    sendablePoint: 0,
-    userId: 0,
-  };
+  try {
+    const response = await loginWithEmailAndPassword(data);
+    storage.setToken(response.data.data.accessToken);
+    const res = await getUser();
+    return res.data.data;
+  } catch (error) {
+    return null;
+  }
 }
 
 async function registerFn(data: RegisterCredentialsDTO) {
-  const response = await registerUser(data);
-  storage.setToken(response.data.data.accessToken);
-  const res = await getUser();
-  return res.data.data;
+  try {
+    const response = await registerUser(data);
+    storage.setToken(response.data.data.accessToken);
+    const res = await getUser();
+    return res.data.data;
+  } catch (error) {
+    return null;
+  }
 }
 
 async function logoutFn() {

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -21,25 +21,21 @@ async function loadUser() {
 }
 
 async function loginFn(data: LoginCredentialsDTO) {
-  try {
-    const response = await loginWithEmailAndPassword(data);
-    storage.setToken(response.data.data.accessToken);
-    const res = await getUser();
-    return res.data.data;
-  } catch (error) {
-    return null;
-  }
+  // lib/react-query-auth.tsxでuseErrorBoundaryをfalseに指定しており、
+  // 例外をキャッチしない設定なのでtry/catchはしない
+  const response = await loginWithEmailAndPassword(data);
+  storage.setToken(response.data.data.accessToken);
+  const res = await getUser();
+  return res.data.data;
 }
 
 async function registerFn(data: RegisterCredentialsDTO) {
-  try {
-    const response = await registerUser(data);
-    storage.setToken(response.data.data.accessToken);
-    const res = await getUser();
-    return res.data.data;
-  } catch (error) {
-    return null;
-  }
+  // lib/react-query-auth.tsxでuseErrorBoundaryをfalseに指定しており、
+  // 例外をキャッチしない設定なのでtry/catchはしない
+  const response = await registerUser(data);
+  storage.setToken(response.data.data.accessToken);
+  const res = await getUser();
+  return res.data.data;
 }
 
 async function logoutFn() {

--- a/src/lib/react-query-auth.tsx
+++ b/src/lib/react-query-auth.tsx
@@ -82,6 +82,7 @@ export function initReactQueryAuth<
     } = useQuery<User, Error>({
       queryKey: [key],
       queryFn: loadUser,
+      useErrorBoundary: false,
     });
 
     const setUser = React.useCallback(
@@ -91,6 +92,7 @@ export function initReactQueryAuth<
 
     const loginMutation = useMutation({
       mutationFn: loginFn,
+      useErrorBoundary: false,
       onSuccess: (user) => {
         setUser(user);
       },
@@ -98,6 +100,7 @@ export function initReactQueryAuth<
 
     const registerMutation = useMutation({
       mutationFn: registerFn,
+      useErrorBoundary: false,
       onSuccess: (user) => {
         setUser(user);
       },
@@ -105,6 +108,7 @@ export function initReactQueryAuth<
 
     const logoutMutation = useMutation({
       mutationFn: logoutFn,
+      useErrorBoundary: false,
       onSuccess: () => {
         queryClient.clear();
       },

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,5 +1,14 @@
-import "../../App.css";
+import { Signup } from "@/features/auth";
+import { Login } from "@/features/auth/component/login";
+import { Box } from "@mui/material";
 
-export const Login = () => {
-  return <h2>ログイン</h2>;
+/**
+ * path: /login
+ */
+export const LoginPage = () => {
+  return (
+    <Box mx="10px">
+      <Login />
+    </Box>
+  );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,9 +19,8 @@ export const getAppRoutes = () => {
         />
       ),
       loader: async () => {
-        // TODO: loginに変更する
         if (!user) {
-          return redirect("/signup");
+          return redirect("/login");
         }
         return redirect("/users");
       },

--- a/src/routes/public.tsx
+++ b/src/routes/public.tsx
@@ -1,5 +1,6 @@
 import { Error } from "@/components/Error";
 import { MainLayout } from "@/components/Layout";
+import { LoginPage } from "@/pages/Login";
 import { lazyImport } from "@/utils/lazyImport";
 import { CircularProgress } from "@mui/material";
 import { Box } from "@mui/system";
@@ -40,10 +41,9 @@ export const publicRoutes: RouteObject[] = [
       {
         errorElement: <Error />,
         children: [
-          {
-            path: "signup",
-            element: <SignupPage />,
-          },
+          { path: "signup", element: <SignupPage /> },
+          { path: "login", element: <LoginPage /> },
+          { path: "password-reset", element: <>パスワードリセット</> },
         ],
       },
     ],


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #15 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- ログイン画面の実装
- `/login`に遷移するとログイン画面 
- トークンがきれいているとき、`/`に飛ぶと`/login`にリダイレクト
- ログイン後は`/users`に遷移
- 未ログイン時に`/users`にアクセスしても401となり見れない
- サインアップ画面へのリンクを実装
- 矢印付きリンクは別コンポーネントとして定義
- 未ログイン時は、アカウントメニュー非表示

見た目

![image](https://user-images.githubusercontent.com/51454617/211147059-ee0be237-f99e-4f76-839e-49a0c307f9e0.png)

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
サインイン機能

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- パスワード忘れた機能は未着手（TODO）