### PR TITLE
#17 アカウント情報閲覧ページ

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,12 +7,13 @@ import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useHandleMenu } from "./hooks";
 
 export const Header = React.memo(() => {
   const { user } = useAuth();
   const { anchorEl, closeMenu, openMenu } = useHandleMenu();
+  const navigate = useNavigate();
 
   return (
     <AppBar position="fixed">
@@ -50,7 +51,14 @@ export const Header = React.memo(() => {
               open={Boolean(anchorEl)}
               onClose={closeMenu}
             >
-              <MenuItem onClick={closeMenu}>アカウント情報</MenuItem>
+              <MenuItem
+                onClick={() => {
+                  closeMenu();
+                  navigate("/account");
+                }}
+              >
+                アカウント情報
+              </MenuItem>
               <MenuItem onClick={closeMenu}>サインアウト</MenuItem>
             </Menu>
           </>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -10,7 +10,7 @@ type MainLayoutProps = {
  * メインレイアウト
  * @param param0 子コンポーネント
  */
-export const MainLayout = ({ children }: MainLayoutProps) => {
+export const MainLayout = React.memo(({ children }: MainLayoutProps) => {
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
       <Header />
@@ -35,4 +35,4 @@ export const MainLayout = ({ children }: MainLayoutProps) => {
       <footer>copy light, point app. inc.</footer>
     </Box>
   );
-};
+});

--- a/src/features/account/component/account.tsx
+++ b/src/features/account/component/account.tsx
@@ -1,0 +1,53 @@
+import { useAuth } from "@/lib/auth";
+import { Box } from "@mui/material";
+import React from "react";
+import { Grid2Layout } from "./grid2Layout";
+
+/**
+ * アカウント情報
+ */
+export const Account: React.FC = React.memo(() => {
+  const { user } = useAuth();
+  return (
+    <Box className="App" mx="auto" maxWidth="800px" mt="100px">
+      <Box component="h1" color="primary.main">
+        アカウント情報
+      </Box>
+      <Box component="p" color="primary.light">
+        アカウント情報の確認・変更ができます
+      </Box>
+      <Box my="60px" />
+      <Grid2Layout
+        title="名前"
+        value={
+          <Box display="flex">
+            <Box color="primary.main" mr="15px">
+              {user?.familyName}
+            </Box>
+            <Box color="primary.main">{user?.firstName}</Box>
+          </Box>
+        }
+      />
+      <Grid2Layout
+        title="フリガナ"
+        value={
+          <Box display="flex">
+            <Box color="primary.main" mr="15px">
+              {user?.familyNameKana}
+            </Box>
+            <Box color="primary.main">{user?.firstNameKana}</Box>
+          </Box>
+        }
+      />
+      <Grid2Layout title="メールアドレス" value={user?.email} />
+      <Grid2Layout
+        title="今月の送付可能ポイント"
+        value={`${user?.sendablePoint} pt`}
+      />
+      <Grid2Layout
+        title="累計獲得ポイント"
+        value={`${user?.acquisitionPoint} pt`}
+      />
+    </Box>
+  );
+});

--- a/src/features/account/component/grid2Layout.tsx
+++ b/src/features/account/component/grid2Layout.tsx
@@ -1,0 +1,46 @@
+import { Box } from "@mui/material";
+import React from "react";
+
+type Props = {
+  title: React.ReactNode;
+  value: React.ReactNode;
+};
+/**
+ * １：２のグリッドレイアウト
+ *
+ * 1:2=title:value
+ *
+ * レスポンシブ対応しており、スマホでは１列になる
+ */
+export const Grid2Layout = React.memo(({ title, value }: Props) => {
+  return (
+    <Box
+      display="flex"
+      my="30px"
+      flexDirection="column"
+      sx={[
+        ({ breakpoints }) => ({
+          [breakpoints.up("sm")]: {
+            flexDirection: "row",
+          },
+        }),
+      ]}
+    >
+      <Box
+        component="h3"
+        flex="1"
+        color="primary.main"
+        sx={[
+          ({ breakpoints }) => ({
+            [breakpoints.up("sm")]: {
+              my: 0,
+            },
+          }),
+        ]}
+      >
+        {title}
+      </Box>
+      <Box flex="2">{value}</Box>
+    </Box>
+  );
+});

--- a/src/features/account/index.ts
+++ b/src/features/account/index.ts
@@ -1,0 +1,1 @@
+export * from "./component/account";

--- a/src/features/auth/component/signup.tsx
+++ b/src/features/auth/component/signup.tsx
@@ -113,7 +113,7 @@ export const Signup: React.FC = React.memo(() => {
             placeholder="太郎"
             type="text"
             variant="outlined"
-            {...register("familyNameKana", {
+            {...register("firstName", {
               required: { value: true, message: ERR_REQUIRE_MESSAGE },
             })}
           />
@@ -128,7 +128,7 @@ export const Signup: React.FC = React.memo(() => {
             placeholder="ヤマダ"
             type="text"
             variant="outlined"
-            {...register("firstName", {
+            {...register("familyNameKana", {
               required: { value: true, message: ERR_REQUIRE_MESSAGE },
             })}
           />

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -1,0 +1,14 @@
+import { Account } from "@/features/account";
+import { Box } from "@mui/material";
+import React from "react";
+
+/**
+ * path: /account
+ */
+export const AccountPage = React.memo(() => {
+  return (
+    <Box mx="10px">
+      <Account />
+    </Box>
+  );
+});

--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Account";

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -1,7 +1,7 @@
 import { Error } from "@/components/Error";
 import { MainLayout } from "@/components/Layout";
 import { useAuth } from "@/lib/auth";
-import { lazyImport } from "@/utils/lazyImport";
+import { AccountPage } from "@/pages/Account";
 import { CircularProgress } from "@mui/material";
 import { Box } from "@mui/system";
 import { Suspense } from "react";
@@ -49,10 +49,8 @@ export const getProtectedRoutes = (): RouteObject[] => {
             return null;
           },
           children: [
-            {
-              path: "users",
-              element: <div>users</div>,
-            },
+            { path: "users", element: <div>users</div> },
+            { path: "account", element: <AccountPage /> },
           ],
         },
       ],


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #17 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- アカウント閲覧ページの作成
- `/account`でアカウント閲覧できる
- 右上のメニューで遷移可能

見た目
PC
![image](https://user-images.githubusercontent.com/51454617/211165450-f1666979-7d1b-451f-8a5a-50c7c95634e6.png)


スマホ

![image](https://user-images.githubusercontent.com/51454617/211165466-f9d0e386-8929-4a42-b393-ca919e478b05.png)

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

- メールアドレス・パスワード変更は実装してません
- ユーザ情報の変更も対応してません