### PR TITLE
#23 ログインなどの時、エラーが消えない不具合修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ logs: ## Tail docker compose logs
 ps: ## Check container status
 	docker compose ps
 
+ci: ## パッケージの導入
+	docker compose run --rm node yarn --frozen-lockfile
+
 help: ## Show options
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-helmet-async": "^1.3.0",
     "react-hook-form": "^7.39.6",
     "react-router-dom": "^6.5.0",
+    "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",
     "recoil-persist": "^4.2.0"
   },

--- a/src/features/auth/component/authCodeModal.tsx
+++ b/src/features/auth/component/authCodeModal.tsx
@@ -66,9 +66,6 @@ export const AuthCodeModal = React.memo(
             <Box sx={{ color: "error.main" }}>
               {errors.confirmCode?.message}
             </Box>
-            <Box sx={{ color: "error.main" }}>
-              {auth.error?.response?.data.message}
-            </Box>
           </DialogContent>
           <DialogActions>
             <Button type="button" onClick={closeModal}>

--- a/src/features/auth/component/login.tsx
+++ b/src/features/auth/component/login.tsx
@@ -29,7 +29,7 @@ export const Login: React.FC = React.memo(() => {
     },
   });
   const navigate = useNavigate();
-  const { login, isLoggingIn, error } = useAuth();
+  const { login, isLoggingIn } = useAuth();
 
   return (
     <Box className="App" mx="auto" maxWidth="400px" mt="100px">
@@ -82,7 +82,6 @@ export const Login: React.FC = React.memo(() => {
             })}
           />
           <Box sx={{ color: "error.main" }}>{errors.password?.message}</Box>
-          <Box color="error.main">{error?.response?.data.message}</Box>
         </Box>
         <LoadingButton
           size="large"

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -39,9 +39,9 @@ async function registerFn(data: RegisterCredentialsDTO) {
 }
 
 async function logoutFn() {
+  window.location.assign(window.location.origin as unknown as string);
   await signout();
   storage.clearToken();
-  window.location.assign(window.location.origin as unknown as string);
 }
 
 const authConfig = {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,6 +1,7 @@
 import { API_URL } from "@/config";
 import storage from "@/utils/storage";
 import Axios, { AxiosError, AxiosRequestConfig } from "axios";
+import { toast } from "react-toastify";
 /**
  * 各リクエストごとにヘッダーを設定するためのインターセプター関数
  * 各リクエスト毎にこの関数が走る
@@ -37,8 +38,12 @@ axios.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
+  (error: ErrResponse) => {
     // エラーのatoms持たせて、ここで突っ込めば共通化できる
+    toast.error(error.response?.data.message, {
+      position: "top-right",
+      autoClose: 10000,
+    });
     return Promise.reject(error);
   }
 );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/lib/auth";
 import { createBrowserRouter, redirect, RouteObject } from "react-router-dom";
 import { getProtectedRoutes } from "./protected";
 import { publicRoutes } from "./public";
+import "react-toastify/dist/ReactToastify.css";
 
 /**
  * 全体のルーティングの設定

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -20,11 +20,11 @@ const App = () => {
             justifyContent="center"
             height="100vh"
           >
-            <ToastContainer />
             <CircularProgress />
           </Box>
         }
       >
+        <ToastContainer />
         <Outlet />
       </Suspense>
     </MainLayout>

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -7,6 +7,7 @@ import { CircularProgress } from "@mui/material";
 import { Box } from "@mui/system";
 import { Suspense } from "react";
 import { Outlet, RouteObject } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 
 const App = () => {
   return (
@@ -19,6 +20,7 @@ const App = () => {
             justifyContent="center"
             height="100vh"
           >
+            <ToastContainer />
             <CircularProgress />
           </Box>
         }

--- a/src/routes/public.tsx
+++ b/src/routes/public.tsx
@@ -6,6 +6,7 @@ import { CircularProgress } from "@mui/material";
 import { Box } from "@mui/system";
 import { Suspense } from "react";
 import { Outlet, RouteObject } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 
 const { SignupPage } = lazyImport(() => import("@/pages/Signup"), "SignupPage");
 
@@ -24,6 +25,7 @@ const App = () => {
           </Box>
         }
       >
+        <ToastContainer />
         <Outlet />
       </Suspense>
     </MainLayout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,7 +964,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-clsx@^1.2.1:
+clsx@^1.1.1, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -2249,6 +2249,13 @@ react-router@6.6.0:
   integrity sha512-+VPfCIaFbkW7BAiB/2oeprxKAt1KLbl+zXZ10CXOYezKWgBmTKyh8XjI53eLqY5kd7uY+V4rh3UW44FclwUU+Q==
   dependencies:
     "@remix-run/router" "1.2.0"
+
+react-toastify@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.1.tgz#9280caea4a13dc1739c350d90660a630807bf10b"
+  integrity sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #23 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- トースターの導入
  - エラー時は必ず表示するようにして、10秒管表示で対応
  - login, registerのエラー表示はこちらのトースタを使った方に変更し、再度エラーページ戻ってもエラーが表示されないようにした
- react-query-authのerrorは、グローバルになっており、エラーが共有されるため、別々の値にした
- react-query-authにエラーを消すための関数clearError関数を用意（login, logout, registerのみ）

![image](https://user-images.githubusercontent.com/51454617/212722459-3f28b96a-d707-44bc-8987-a67afd48d552.png)

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
新しいパッケージ導入しています
```sh
$ make ci
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
