### PR TITLE
Feature/#30 パスワードリセットページの作成

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,10 +9,6 @@ module.exports = {
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    //
-    // "plugin:import/recommended",
-    // "plugin:import/typescript",
-    // "plugin:import/warnings",
   ],
   overrides: [],
   parser: "@typescript-eslint/parser",
@@ -28,8 +24,6 @@ module.exports = {
   rules: {
     "react/react-in-jsx-scope": "off",
     "react/display-name": "off",
-    //
-    // "import/newline-after-import": "error",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
   },

--- a/src/features/auth/api/resetPassword.tsx
+++ b/src/features/auth/api/resetPassword.tsx
@@ -1,0 +1,11 @@
+import { axios, SuccessResponse } from "@/lib/axios";
+
+export type ResetPasswordResponse = SuccessResponse<null>;
+
+export type ResetPasswordDTO = {
+  email: string;
+};
+
+export const resetPassword = (data: ResetPasswordDTO) => {
+  return axios.patch<ResetPasswordResponse>("/random_password", data);
+};

--- a/src/features/auth/component/passwordReset.tsx
+++ b/src/features/auth/component/passwordReset.tsx
@@ -1,0 +1,93 @@
+import { LoadingButton } from "@mui/lab";
+import { Box, TextField } from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import {
+  ERR_MAIL_FORMAT_MESSAGE,
+  ERR_REQUIRE_MESSAGE,
+  MAIL_FORMAT_REGEXP,
+  MAX_MAIL_LENGTH,
+} from "@/const/const";
+import { ErrResponse } from "@/lib/axios";
+
+import { resetPassword, ResetPasswordDTO } from "../api/resetPassword";
+
+/**
+ * パスワードリセット機能
+ */
+export const PasswordReset: React.FC = React.memo(() => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      email: "",
+    },
+  });
+  const navigate = useNavigate();
+  const { mutate, isLoading } = useMutation(
+    (data: ResetPasswordDTO) => resetPassword(data),
+    {
+      onSuccess: () => {
+        navigate("/login");
+      },
+      onError: (err: ErrResponse) => {
+        if (err.response?.status === 404) {
+          setError(
+            "email",
+            { message: err.response.data.message },
+            { shouldFocus: true }
+          );
+          return;
+        }
+      },
+    }
+  );
+
+  return (
+    <Box className="App" mx="auto" maxWidth="400px" mt="100px">
+      <Box textAlign="center" component="h2" mb="60px" color="#333">
+        パスワードリセット
+      </Box>
+      <form onSubmit={handleSubmit((data) => mutate(data))}>
+        <Box marginBottom="24px">
+          <Box mb="4px">メールアドレス</Box>
+          <TextField
+            fullWidth
+            placeholder="yamada.taro@example.com"
+            variant="outlined"
+            type="email"
+            {...register("email", {
+              required: { value: true, message: ERR_REQUIRE_MESSAGE },
+              pattern: {
+                value: MAIL_FORMAT_REGEXP,
+                message: ERR_MAIL_FORMAT_MESSAGE,
+              },
+              maxLength: {
+                value: MAX_MAIL_LENGTH.VALUE,
+                message: MAX_MAIL_LENGTH.MESSAGE,
+              },
+            })}
+          />
+          <Box sx={{ color: "error.main" }}>{errors.email?.message}</Box>
+        </Box>
+        <LoadingButton
+          size="large"
+          fullWidth
+          sx={{ marginTop: "50px" }}
+          variant="contained"
+          type="submit"
+          color="primary"
+          loading={isLoading}
+        >
+          リセットメール送信
+        </LoadingButton>
+      </form>
+    </Box>
+  );
+});

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,3 +1,4 @@
 export * from "./api/register";
 export * from "./api/temporaryRegister";
+export * from "./component/passwordReset";
 export * from "./component/signup";

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,9 +1,8 @@
 import Axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { API_URL } from "@/config";
+import * as snackbar from "@/lib/toast";
 import storage from "@/utils/storage";
-
-import * as snackbar from "./toast";
 
 /**
  * 各リクエストごとにヘッダーを設定するためのインターセプター関数

--- a/src/pages/PasswordReset/PasswordReset.tsx
+++ b/src/pages/PasswordReset/PasswordReset.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@mui/material";
+
+import { PasswordReset } from "@/features/auth";
+
+/**
+ * path: /password-reset
+ */
+export const PasswordResetPage = () => {
+  return (
+    <Box mx="10px">
+      <PasswordReset />
+    </Box>
+  );
+};

--- a/src/pages/PasswordReset/index.tsx
+++ b/src/pages/PasswordReset/index.tsx
@@ -1,0 +1,1 @@
+export * from "./PasswordReset";

--- a/src/routes/public.tsx
+++ b/src/routes/public.tsx
@@ -7,6 +7,7 @@ import { ToastContainer } from "react-toastify";
 import { Error } from "@/components/Error";
 import { MainLayout } from "@/components/Layout";
 import { LoginPage } from "@/pages/Login";
+import { PasswordResetPage } from "@/pages/PasswordReset";
 import { lazyImport } from "@/utils/lazyImport";
 
 const { SignupPage } = lazyImport(() => import("@/pages/Signup"), "SignupPage");
@@ -46,7 +47,7 @@ export const publicRoutes: RouteObject[] = [
         children: [
           { path: "signup", element: <SignupPage /> },
           { path: "login", element: <LoginPage /> },
-          { path: "password-reset", element: <>パスワードリセット</> },
+          { path: "password-reset", element: <PasswordResetPage /> },
         ],
       },
     ],


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #30 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* パスワードリセットページを作成(/password-reset)
* メールアドレスが存在しない時は、その旨をユーザに知らせる（セキュリティ的によくない場合は後に仕様変更可能）

![image](https://user-images.githubusercontent.com/51454617/216759073-9e22d08c-59f4-41c9-9058-f5474d46bf44.png)

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
なし