### PR TITLE
push時のCI設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
       - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合はCI失敗とする
-        run: |
-          exit $(git status --porcelain | wc -l)
-          git status --porcelain
+        run: git diff --name-only --diff-filter=d | sed '/^$/d' | awk '{print "\033[0;31m" $0 "\033[0m"} END{if(NR>0) exit 1}'
         shell: bash
       - name: test-kudo
         run:  echo This is test event 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合はCI失敗とする
         run: |
           exit $(git status --porcelain | wc -l)
-          echo $(git status --porcelain)
+          git status --porcelain
         shell: bash
       - name: test-kudo
         run:  echo This is test event 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+on: push
+jobs:
+  lint-format: # ジョブ作成
+    name: test-lint-format # ジョブ名の指定
+    runs-on: ubuntu-latest # GitHubが提供する仮想マシンの指定(最新の安定したイメージ)
+    steps:
+      - name: test-kudo
+        run:  echo This is test event 
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: push
+on: # トリガーは特定のブランチへのプッシュ時にする
+  push:
+    branches:
+      - 'main'
+      - 'develop'
 jobs:
   lint-format: # ジョブ作成
     name: lint-format # ジョブ名の指定

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,4 @@ jobs:
       - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合は赤文字でファイル名を出力しCI失敗とする
         run: git diff --name-only --diff-filter=d | sed '/^$/d' | awk '{print "\033[0;31m" $0 "\033[0m"} END{if(NR>0) exit 1}'
         shell: bash
-      - name: test-kudo
-        run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 jobs:
   lint-format: # ジョブ作成
-    name: test-lint-format # ジョブ名の指定
+    name: lint-format # ジョブ名の指定
     runs-on: ubuntu-latest # GitHubが提供する仮想マシンの指定(最新の安定したイメージ)
     strategy: # Nodeのバージョン指定(マトリックス戦略)
       matrix:
@@ -20,7 +20,7 @@ jobs:
       - name: Install package
         run: yarn --frozen-lockfile
       - name: Run format(prettier) and lint(eslint)
-        run: yarn format && yarn lint
+        run: yarn lint
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
-      - name: Fail on format(prettier) and lint(eslint) errors
-        run: exit $(git status --porcelain)
+      - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合はCI失敗とする
+        run: exit $(git status --porcelain | wc -l) echo $(git status --porcelain)
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
       - name: Fail on format(prettier) and lint(eslint) errors
-        run: exit $(git status --porcelain | grep '^[MARCD]' | wc -l)
+        run: exit $(git status --porcelain | wc -l)
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
       - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合はCI失敗とする
-        run: exit $(git status --porcelain | wc -l) echo $(git status --porcelain)
+        run: |
+          exit $(git status --porcelain | wc -l)
+          echo $(git status --porcelain)
+        shell: bash
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
-      - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合はCI失敗とする
+      - name: Fail on format(prettier) and lint(eslint) errors # formatとlint結果でファイル変更があった場合は赤文字でファイル名を出力しCI失敗とする
         run: git diff --name-only --diff-filter=d | sed '/^$/d' | awk '{print "\033[0;31m" $0 "\033[0m"} END{if(NR>0) exit 1}'
         shell: bash
       - name: test-kudo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,19 @@ jobs:
   lint-format: # ジョブ作成
     name: test-lint-format # ジョブ名の指定
     runs-on: ubuntu-latest # GitHubが提供する仮想マシンの指定(最新の安定したイメージ)
+    strategy: # Nodeのバージョン指定(マトリックス戦略)
+      matrix:
+        node-version: [18.x]
     steps:
+      - name: Git checkout current branch # pushした時のブランチにcheckoutする
+        uses: actions/checkout@v3 #サードパーティの公開アクションを利用
+        with:
+          ref: ${{ github.ref }} # ジョブがトリガーされたGitリポジトリの参照を表す環境変数
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm # cacheを利用
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm # cacheを利用
+          cache: yarn # cacheを利用
       - name: Install package
-        run: npm ci
+        run: yarn --frozen-lockfile
       - name: Run format(prettier) and lint(eslint)
-        run: npm run format && npm run lint
+        run: yarn format && yarn lint
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run format(prettier) and lint(eslint)
         run: yarn format && yarn lint
       - name: Fail on format(prettier) and lint(eslint) errors
-        run: exit $(git status --porcelain | wc -l)
+        run: exit $(git status --porcelain)
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm # cacheを利用
+      - name: Install package
+        run: npm ci
+      - name: Run format(prettier) and lint(eslint)
+        run: npm run format && npm run lint
       - name: test-kudo
         run:  echo This is test event 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Install package
         run: yarn --frozen-lockfile
       - name: Run format(prettier) and lint(eslint)
-        run: yarn lint
+        run: yarn format && yarn lint
+      - name: Fail on format(prettier) and lint(eslint) errors
+        run: exit $(git status --porcelain | grep '^[MARCD]' | wc -l)
       - name: test-kudo
         run:  echo This is test event 
 

--- a/src/features/account/component/accountUpdate.tsx
+++ b/src/features/account/component/accountUpdate.tsx
@@ -1,9 +1,9 @@
-import { LoadingButton } from "@mui/lab";
 import { Box, TextField } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
 import React from "react";
 import { useForm } from "react-hook-form";
 
+import { LoadingButton } from "@mui/lab";
 import { ERR_REQUIRE_MESSAGE, MAX_USERNAME_LENGTH } from "@/const/const";
 import { useAuth } from "@/lib/auth";
 

--- a/src/features/account/component/accountUpdate.tsx
+++ b/src/features/account/component/accountUpdate.tsx
@@ -1,9 +1,9 @@
+import { LoadingButton } from "@mui/lab";
 import { Box, TextField } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
 import React from "react";
 import { useForm } from "react-hook-form";
 
-import { LoadingButton } from "@mui/lab";
 import { ERR_REQUIRE_MESSAGE, MAX_USERNAME_LENGTH } from "@/const/const";
 import { useAuth } from "@/lib/auth";
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #39 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
.gihub配下にworkflows/ci.ymlを作成し、formatとlintを実行するよう処理を記載しました。
formatとlint実行によって変更があったファイルがある場合はCI失敗とし、ファイル名を出力するようにしています。
<img width="1058" alt="スクリーンショット 2023-03-21 14 05 44" src="https://user-images.githubusercontent.com/72244748/226524206-c72200b7-1ce9-40b6-b421-db34605b085c.png">


# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作確認したこと
- formatとlintをローカルで実行していないでpushしたときにCI失敗になること
- formatとlintをローカルで実行してpushしたときにCI成功になること

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->