### PR TITLE
#60 プッシュ通知の実装

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -76,6 +76,14 @@ export const Header = React.memo(() => {
                 アカウント情報
               </MenuItem>
               <MenuItem
+                onClick={() => {
+                  closeMenu();
+                  navigate("/settings/notification");
+                }}
+              >
+                設定
+              </MenuItem>
+              <MenuItem
                 onClick={async () => {
                   closeMenu();
                   logout();

--- a/src/features/notification/api/getUncheckedNotificationCount.ts
+++ b/src/features/notification/api/getUncheckedNotificationCount.ts
@@ -53,6 +53,15 @@ export function useFetchUncheckedNotificationCount():
           event.data
         ) as GetUncheckedNotificationCountResponse;
         data$.current = parsedData;
+        // 通知
+        if (Notification.permission === "granted" && parsedData.count > 0) {
+          new Notification("ポイントアプリ", {
+            body: parsedData.count + "件の未読通知があります",
+            silent: false,
+            icon: "/icon-192.png",
+            image: "/icon-192.png",
+          });
+        }
         onStoreChange();
       },
       signal: controller.signal,

--- a/src/features/settings/component/notification.tsx
+++ b/src/features/settings/component/notification.tsx
@@ -1,0 +1,25 @@
+import { Box, Button } from "@mui/material";
+import React from "react";
+
+import { askNotificationPermission } from "../function/notification";
+import { SideBarLayout } from "./sideBarLayout";
+
+/**
+ * 通知設定
+ */
+export const Notification: React.FC = React.memo(() => {
+  return (
+    <SideBarLayout>
+      <Box component="h1" color="primary.main">
+        通知
+      </Box>
+      <Box component="p" color="primary.light">
+        通知に関する設定ができます
+      </Box>
+      <Box my="60px" />
+      <Button variant="contained" onClick={askNotificationPermission}>
+        通知を受け取る
+      </Button>
+    </SideBarLayout>
+  );
+});

--- a/src/features/settings/component/sideBarLayout.tsx
+++ b/src/features/settings/component/sideBarLayout.tsx
@@ -1,0 +1,96 @@
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import {
+  Box,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+type Props = {
+  children: React.ReactNode;
+};
+/**
+ * 設定画面サイドバーコンポーネント
+ *
+ * mainコンテンツは子コンポーネントに指定すること
+ * @param param0.children メインコンテンツ
+ */
+export const SideBarLayout = React.memo(({ children }: Props) => {
+  const navigationList = [{ link: "settings/notification", text: "通知" }];
+  // レスポンシブかどうかを取得する
+  const { breakpoints } = useTheme();
+  const isMobile = useMediaQuery(breakpoints.down("sm"));
+
+  return (
+    <Box
+      maxWidth="1200px"
+      display="flex"
+      flexDirection="column"
+      sx={[
+        ({ breakpoints }) => ({
+          [breakpoints.up("sm")]: {
+            mt: "100px",
+            flexDirection: "row",
+          },
+        }),
+      ]}
+    >
+      <Box
+        sx={{
+          overflow: "auto",
+          "& .active": {
+            color: "#bbb",
+          },
+          "& .active .MuiListItemIcon-root": {
+            color: "#bbb",
+          },
+        }}
+        flex={1}
+      >
+        <List>
+          {navigationList.map((navigation) => (
+            <NavLink
+              key={navigation.link}
+              to={`/${navigation.link}`}
+              className={({ isActive, isPending }) =>
+                isActive ? "active" : isPending ? "pending" : ""
+              }
+            >
+              <ListItem disablePadding>
+                <ListItemButton>
+                  <ListItemText primary={navigation.text} />
+                  {isMobile ? (
+                    <KeyboardArrowDownIcon />
+                  ) : (
+                    <KeyboardArrowRightIcon />
+                  )}
+                </ListItemButton>
+              </ListItem>
+            </NavLink>
+          ))}
+        </List>
+      </Box>
+      <Box
+        flex={3}
+        sx={[
+          ({ breakpoints }) => ({
+            [breakpoints.up("sm")]: {
+              ml: "50px",
+            },
+            [breakpoints.up("md")]: {
+              ml: "100px",
+            },
+          }),
+        ]}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+});

--- a/src/features/settings/function/notification.ts
+++ b/src/features/settings/function/notification.ts
@@ -1,0 +1,22 @@
+import * as snackbar from "@/lib/toast";
+
+/**
+ * 通知の許可を求める
+ *
+ * 通知が許可されていない場合、許可を求める
+ *
+ * 通知が許可されている場合、通知は許可されていますと表示する
+ * @returns void
+ */
+export function askNotificationPermission() {
+  if (!("Notification" in window)) return;
+  if (window.Notification.permission !== "granted") {
+    window.Notification.requestPermission().then(() => {
+      snackbar.success("通知を許可しました");
+    });
+    return;
+  }
+  window.Notification.requestPermission(function () {
+    snackbar.success("通知は許可されています");
+  });
+}

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./component/notification";

--- a/src/pages/SettingsNotification/SettingsNotification.tsx
+++ b/src/pages/SettingsNotification/SettingsNotification.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@mui/material";
+
+import { Notification } from "@/features/settings";
+
+/**
+ * path: /settings/notification
+ */
+export const SettingsNotification = () => {
+  return (
+    <Box mx="10px">
+      <Notification />
+    </Box>
+  );
+};

--- a/src/pages/SettingsNotification/index.ts
+++ b/src/pages/SettingsNotification/index.ts
@@ -1,0 +1,1 @@
+export * from "./SettingsNotification";

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -14,6 +14,7 @@ import { LoginPage } from "@/pages/Login";
 import { NotificationPage } from "@/pages/Notification";
 import { NotificationsPage } from "@/pages/Notifications";
 import { PasswordUpdatePage } from "@/pages/PasswordUpdate";
+import { SettingsNotification } from "@/pages/SettingsNotification";
 import { UsersPage } from "@/pages/Users";
 import storage from "@/utils/storage";
 
@@ -96,6 +97,12 @@ export const getProtectedRoutes = (): RouteObject[] => {
             {
               path: "notifications/:notificationId",
               element: <NotificationPage />,
+            },
+            {
+              path: "settings",
+              children: [
+                { path: "notification", element: <SettingsNotification /> },
+              ],
             },
           ],
         },


### PR DESCRIPTION
- **add:#60 通知を受けた時お知らせする**
- **add:#60 通知設定ページの作成**
- **add:#60 ルーティング**
- **add:#60 ヘッダーから設定にアクセスできるようにする**

<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #60

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- プッシュ通知を設定するための画面追加
  - settings/notificationにアクセスすることで設定へ飛ぶ
- ブラウザを飛来いているときにお知らせを受けるとプッシュ通知する

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

なし
