### PR TITLE
#67 ローディング画面が止まる不具合の修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
     platform: linux/amd64
     ports:
       - "3001:4010"
-    command: mock  -h 0.0.0.0 https://Yuki-TU.github.io/point-app-backend/openapi.yml
+    command: mock --host 0.0.0.0 --multiprocess false https://Yuki-TU.github.io/point-app-backend/openapi.yml

--- a/src/providers/app.tsx
+++ b/src/providers/app.tsx
@@ -6,11 +6,12 @@ import {
 } from "@mui/material";
 import { QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
+import { useMemo } from "react";
 import { RouterProvider } from "react-router";
 import { ToastContainer } from "react-toastify";
 import { RecoilRoot } from "recoil";
 
-import { AuthProvider } from "@/lib/auth";
+import { AuthProvider, useAuth } from "@/lib/auth";
 import { queryClient } from "@/lib/react-query";
 import { getAppRoutes } from "@/routes";
 
@@ -52,5 +53,7 @@ export const AppProvider = () => {
  * そうしないとエラーになる
  */
 const WrapRouterProvider = () => {
-  return <RouterProvider router={getAppRoutes()} />;
+  const { user } = useAuth();
+  const router = useMemo(() => getAppRoutes(), [user]);
+  return <RouterProvider router={router} />;
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,5 @@
 import "react-toastify/dist/ReactToastify.css";
 
-import { CircularProgress } from "@mui/material";
-import { Box } from "@mui/system";
 import { createBrowserRouter, redirect, RouteObject } from "react-router";
 
 import { Error } from "@/components/Error";
@@ -24,21 +22,8 @@ export const getAppRoutes = () => {
           message="このページはすでに削除されているか、URLが間違っている可能性があります。"
         />
       ),
-      element: null,
-      HydrateFallback: () => (
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          height="100vh"
-        >
-          <CircularProgress />
-        </Box>
-      ),
       loader: async () => {
         if (!user) {
-          // TODO: もしかしたらこっちでリダイレクトしないといけないかも
-          // window.location.pathname = "/login";
           return redirect("/login");
         }
         return redirect("/users");


### PR DESCRIPTION
- **fix:#67 リダイレクトルートの HydrateFallback を削除**
- **fix:#67 ルーター生成を useMemo で安定化**
- **fix:#67 Prism モック API の起動コマンドを修正**

<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #67

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- `routes/index.tsx` から `element: null` と `HydrateFallback` を削除し、SPA でローディングが解除されない問題を修正
- `app.tsx` でルーター生成を `useMemo` 化し、再レンダーごとの再生成を防止
- `docker-compose.yml` の Prism 起動コマンドを `--host 0.0.0.0 --multiprocess false` に修正

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- ローカル開発環境の起動・画面表示
- モック API（`localhost:3001`）の起動

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- `make up` でコンテナ起動後、`http://localhost:3000` でログイン画面が表示されること
- `docker compose ps` で `api` コンテナが起動していること

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- `HydrateFallback` は React Router v7 の Framework SPA モード向けの機能であり、今回の `createBrowserRouter` 構成では不要

Made with [Cursor](https://cursor.com)